### PR TITLE
基于Fast/Slow反馈，独立调整每首歌不同难度的点击延迟偏移

### DIFF
--- a/src/autodori.py
+++ b/src/autodori.py
@@ -46,13 +46,14 @@ from minitouchpy import (
 import player
 from api import BestdoriAPI
 from chart import Chart, PlayRecord
+from latency import load_offsets, save_offset, get_offset
 from util import *
 
 MIN_LIVEBOOST = 1
 LIVEMODE = "freelive"
 DIFFICULTY = "hard"
 OFFSET = {"up": 0, "down": 0, "move": 0, "wait": 0.0, "interval": 0.0}
-PHOTOGATE_LATENCY = 30
+DEFAULT_PHOTOGATE_LATENCY = 50
 DEFAULT_MOVE_SLICE_SIZE = 10
 MAX_FAILED_TIMES = 10
 CMD_SLICE_SIZE = 100
@@ -73,6 +74,7 @@ all_song_name_indexes: dict[str, str] = {
 current_song_name: str = None
 current_song_id: str = None
 current_chart: Chart = None
+current_latency = 0
 play_failed_times: int = 0
 callback_data: dict = {}
 callback_data_lock = threading.Lock()
@@ -269,12 +271,27 @@ class PlayResultRecognition(CustomRecognition):
 class SavePlayResult(CustomAction):
     def run(self, context: Context, argv: CustomAction.RunArg):
         try:
-            global current_song_id, play_failed_times
+            global current_song_id, current_latency, play_failed_times
             succeed: bool = json.loads(argv.custom_action_param).get("succeed")
             if succeed:
                 playresult = argv.reco_detail.best_result.detail
                 if isinstance(playresult, str):
                     playresult = json.loads(argv.reco_detail.best_result.detail)
+                fast = playresult.get("fast", 0)
+                slow = playresult.get("slow", 0)
+                if fast > slow:
+                    new_latency = current_latency + 10
+                elif slow > fast:
+                    new_latency = current_latency - 10
+                else:
+                    new_latency = current_latency
+                new_latency = max(-DEFAULT_PHOTOGATE_LATENCY, min(80, new_latency))
+                if new_latency != current_latency:
+                    save_offset(current_song_id, DIFFICULTY, new_latency)
+                    current_latency = new_latency
+                    logging.info(f"Adjusted latency for {current_song_id}_{DIFFICULTY} to {new_latency}ms")
+                else:
+                    logging.debug("Latency unchanged.")
             else:
                 play_failed_times += 1
                 playresult = {}
@@ -350,7 +367,7 @@ def _get_orientation():
 
 
 def save_song(name):
-    global current_song_name, current_song_id, current_chart, current_orientation
+    global current_song_name, current_song_id, current_chart, current_orientation, current_latency
     current_song_name = name
     current_song_id = all_song_name_indexes[current_song_name]
     current_chart = Chart((current_song_id, DIFFICULTY), current_song_name)
@@ -359,6 +376,8 @@ def save_song(name):
     current_chart.actions_to_MNTcmd(
         (mnt.max_x, mnt.max_y), current_orientation, OFFSET, CMD_SLICE_SIZE
     )
+    current_latency = get_offset(current_song_id, DIFFICULTY)
+    logging.debug(f"Loaded latency for {name}({DIFFICULTY}): {current_latency}ms")
     logging.debug("Save song: {}".format(name))
 
 
@@ -429,7 +448,7 @@ def wait_first_note():
                         logging.debug(
                             f"The first note falls between {from_row}-{to_row}"
                         )
-                        time.sleep(PHOTOGATE_LATENCY / 1000)
+                        time.sleep(max(0, (DEFAULT_PHOTOGATE_LATENCY + current_latency) / 1000))
                         break
                 else:
                     if not freezed:
@@ -679,6 +698,8 @@ def check_update():
 
 def main():
     configure_log()
+
+    load_offsets()
 
     parser = argparse.ArgumentParser(
         description="AutoDori script with different modes."

--- a/src/latency.py
+++ b/src/latency.py
@@ -1,0 +1,73 @@
+import json
+from pathlib import Path
+
+# 偏移量存储文件路径
+LATENCY_FILE = Path("data/latency.json")
+# 难度排序
+DIFFICULTY_ORDER = {
+    "easy": 0,
+    "normal": 1,
+    "hard": 2,
+    "expert": 3,
+    "special": 4,
+}
+
+# 内存缓存，避免频繁读取文件
+_latency_cache = {}
+
+def load_offsets() -> dict:
+    """
+    从 LATENCY_FILE 加载所有偏移数据到内存缓存，并返回缓存字典。
+    若文件不存在，则返回空字典。
+    """
+    global _latency_cache
+    if LATENCY_FILE.exists():
+        try:
+            with open(LATENCY_FILE, "r", encoding="utf-8") as f:
+                _latency_cache = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            # 若文件损坏，重置为空
+            _latency_cache = {}
+    else:
+        _latency_cache = {}
+    return _latency_cache
+
+def save_offset(song_id: str, difficulty: str, new_offset: int) -> None:
+    """
+    保存指定歌曲和难度的偏移值到文件。
+    """
+    global _latency_cache
+    if not _latency_cache:
+        load_offsets()
+    
+    key = f"{song_id}_{difficulty}"
+    # 更新缓存
+    _latency_cache[key] = new_offset
+    
+    # 确保 data 目录存在
+    LATENCY_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+    # 排序
+    sorted_items = dict(
+        sorted(
+            _latency_cache.items(),
+            key=lambda item: (
+                int(item[0].split("_")[0]),                # ID 转为数字排序
+                DIFFICULTY_ORDER.get(item[0].split("_")[1], 99)  # 难度按映射排序
+            )
+        )
+    )
+    # 写入文件
+    with open(LATENCY_FILE, "w", encoding="utf-8") as f:
+        json.dump(sorted_items, f, ensure_ascii=False, indent=2)
+
+def get_offset(song_id: str, difficulty: str) -> int:
+    """
+    获取指定歌曲和难度的偏移值。
+    """
+    global _latency_cache
+    # 若缓存为空，则加载
+    if not _latency_cache:
+        load_offsets()
+    key = f"{song_id}_{difficulty}"
+    return _latency_cache.get(key, 0)

--- a/src/test.py
+++ b/src/test.py
@@ -4,7 +4,7 @@ FUZZYSONGNAME = "寄る辺のSunny,Sunny"
 
 autodori.DIFFICULTY = "expert"
 autodori.OFFSET = {"up": 0, "down": 0, "move": 0, "wait": 0.0, "interval": 0.0}
-autodori.PHOTOGATE_LATENCY = 30
+autodori.DEFAULT_PHOTOGATE_LATENCY = 30
 autodori.DEFAULT_MOVE_SLICE_SIZE = 20
 autodori.CMD_SLICE_SIZE = 100
 

--- a/src/util.py
+++ b/src/util.py
@@ -28,8 +28,8 @@ def get_runtime_info(resolution: tuple[int, int]):
             "h": get_rounded_int_y(590),
         },
         "wait_first": {
-            "from": get_rounded_int_y(510),
-            "to": get_rounded_int_y(535),
+            "from": get_rounded_int_y(450),
+            "to": get_rounded_int_y(475),
         },
     }
 


### PR DESCRIPTION
目前所有歌曲和难度共用同一个延迟值 `PHOTOGATE_LATENCY` 。实际测试发现，不同歌曲、不同难度对延迟的敏感度存在差异，（在我的电脑上）主要表现为一些歌正常，而一些歌总是slow。为此加入了为不同歌曲和不同难度建立独立的延迟偏移量，并通过演奏后的Fast/Slow数目反馈自动校准的功能。

## 功能

### 1. 独立存储每首歌/难度的偏移值

新增 `latency.py` ，用于读取、存储延迟偏移数据（存在 `data/latency.json` ）。

### 2. 自动调整延迟偏移

每次演奏结束后，获取Fast、Slow个数，若 Fast > Slow，增加10ms延迟，其它情况则减少10ms或不变。

为了实现-50ms到+80ms的调整范围，略微抬高了 `util.py` 中图形检测第一个按键的检测高度，给 `wait_first_note()` 的 `sleep()` 留更多时间。主要是有的歌即使把睡眠时间调成0它还是slow，不得已只能这样了

现在 `wait_first_note()` 中睡眠时间改为 `(DEFAULT_PHOTOGATE_LATENCY + current_latency) / 1000`。 `DEFAULT_PHOTOGATE_LATENCY` 是之前的 `PHOTOGATE_LATENCY` ，改为50ms以匹配修改后的图形检测高度； `current_latency` 是读取的曲目单独的延迟偏移值，范围在-50ms到+80ms。

## 修改文件清单

| 文件 | 变更类型 | 说明 |
| :--- | :--- | :--- |
| `latency.py` | **新增** | 偏移数据读取、存储：`load_offsets`、`save_offset`、`get_offset` |
| `autodori.py` | 修改 | 调整偏移，修改 `wait_first_note` 中sleep的时间，`SavePlayResult` 中获取Fast/Slow个数、调整偏移并储存，在 `save_song` 开头加载偏移 |
| `util.py` | 修改 | 抬高了检测第一个按键的图形位置 |
| `test.py` | 修改 | `PHOTOGATE_LATENCY`名字改了，也跟着改一下 |

## 测试情况

只试了十几首歌的EZ和NM难度，目前没有问题，延迟可以正确调整。